### PR TITLE
Added ability to setTestMode to true/false

### DIFF
--- a/src/Omnipay/Pin/Gateway.php
+++ b/src/Omnipay/Pin/Gateway.php
@@ -35,6 +35,11 @@ class Gateway extends AbstractGateway
         return $this->setParameter('secretKey', $value);
     }
 
+    public function setTestMode($value)
+    {
+        return $this->setParameter('testMode', $value);
+    }
+    
     public function purchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Pin\Message\PurchaseRequest', $parameters);


### PR DESCRIPTION
I was getting API auth failures with this class, and finally worked out it was because it was hitting up the live API. I had a key for the test API. I've added a function called "setTestMode", so the user can set the mode to true/false:

$gateway->setTestMode(true);

If it's true, it'll use the dev API. A false will use the live API.

Previously, the other way of doing it was going into the class and changing it manually. This change gives options.
