### PR TITLE
Rename getCustomerToken and getCardToken functions

### DIFF
--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -60,7 +60,7 @@ namespace Omnipay\Pin\Message;
  *   ))->send();
  *   if ($response->isSuccessful()) {
  *       // Find the card ID
- *       $card_id = $response->getCardToken();
+ *       $card_id = $response->getCardReference();
  *   } else {
  *       echo "Gateway createCard failed.\n";
  *       echo "Error message == " . $response->getMessage() . "\n";

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -29,14 +29,14 @@ class Response extends AbstractResponse
     }
 
     /**
-     * Get Card Token
+     * Get Card Reference
      *
      * This is used after createCard to get the credit card token to be
      * used in future transactions.
      *
      * @return string
      */
-    public function getCardToken()
+    public function getCardReference()
     {
         if (isset($this->data['response']['token'])) {
             return $this->data['response']['token'];
@@ -44,18 +44,34 @@ class Response extends AbstractResponse
     }
 
     /**
-     * Get Customer Token
+     * @deprecated
+     */
+    public function getCardToken()
+    {
+        return $this->getCardReference();
+    }
+
+    /**
+     * Get Customer Reference
      *
      * This is used after createCustomer to get the customer token to be
      * used in future transactions.
      *
      * @return string
      */
-    public function getCustomerToken()
+    public function getCustomerReference()
     {
         if (isset($this->data['response']['token'])) {
             return $this->data['response']['token'];
         }
+    }
+
+    /**
+     * @deprecated
+     */
+    public function getCustomerToken()
+    {
+        return $this->getCustomerReference();
     }
 
     public function getMessage()

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -66,7 +66,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertSame('Refund amount is more than your available Pin Payments balance.', $response->getMessage());
     }
 
-    public function testGetCardTokenSuccess()
+    public function testGetCardReferenceSuccess()
     {
         $this->setMockHttpResponse('CardSuccess.txt');
 
@@ -74,7 +74,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardToken());
+        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -86,7 +86,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCardToken());
+        $this->assertNull($response->getCardReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 
@@ -98,7 +98,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerToken());
+        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -110,7 +110,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCustomerToken());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 }

--- a/tests/Message/CreateCardRequestTest.php
+++ b/tests/Message/CreateCardRequestTest.php
@@ -33,7 +33,7 @@ class CreateCardRequestTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardToken());
+        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -44,7 +44,7 @@ class CreateCardRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCardToken());
+        $this->assertNull($response->getCardReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 }

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -17,7 +17,7 @@ class CreateCustomerRequestTest extends TestCase
         );
     }
 
-    public function testDataWithCardToken()
+    public function testDataWithCardReference()
     {
         $this->request->setToken('card_abc');
         $data = $this->request->getData();
@@ -42,7 +42,7 @@ class CreateCustomerRequestTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerToken());
+        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -53,7 +53,7 @@ class CreateCustomerRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCustomerToken());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -35,7 +35,7 @@ class ResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardToken());
+        $this->assertEquals('card_8LmnNMTYWG4zQZ4YnYQhBg', $response->getCardReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -46,7 +46,7 @@ class ResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCardToken());
+        $this->assertNull($response->getCardReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 
@@ -57,7 +57,7 @@ class ResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerToken());
+        $this->assertEquals('cus_Mb-8S1ZgEbLUUUJ97dfhfQ', $response->getCustomerReference());
         $this->assertTrue($response->getMessage());
     }
 
@@ -68,7 +68,7 @@ class ResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getCustomerToken());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
 }


### PR DESCRIPTION
Rename getCustomerToken and getCardToken functions to getCustomerReference and getCardReference for compatibility with other gateways.  Also the function in the parent Omnipay\Common\Message]AbstractRequest class is called getCardReference not getCardToken.

I have left behind a backwards compatibility shim so nothing should break.