### PR TITLE
Adding ability to capture pre authorised payment

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -133,6 +133,11 @@ class Gateway extends AbstractGateway
         return $this->createRequest('\Omnipay\Pin\Message\PurchaseRequest', $parameters);
     }
 
+    public function capture(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Pin\Message\CaptureRequest', $parameters);
+    }
+
     public function refund(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Pin\Message\RefundRequest', $parameters);

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -21,7 +21,10 @@ class CaptureRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->sendRequest('/charges/' . $this->getTransactionReference() . '/capture', $data, RequestInterface::PUT);
+        $httpResponse = $this->sendRequest(
+            '/charges/' . $this->getTransactionReference() . '/capture', $data,
+            RequestInterface::PUT
+        );
         return $this->response = new CaptureResponse($this, $httpResponse->json());
     }
 }

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -22,7 +22,8 @@ class CaptureRequest extends AbstractRequest
     public function sendData($data)
     {
         $httpResponse = $this->sendRequest(
-            '/charges/' . $this->getTransactionReference() . '/capture', $data,
+            '/charges/' . $this->getTransactionReference() . '/capture',
+            $data,
             RequestInterface::PUT
         );
         return $this->response = new CaptureResponse($this, $httpResponse->json());

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\Pin\Message;
 
+use Guzzle\Http\Message\RequestInterface;
+
 /**
  * Pin Capture Request
  */
@@ -9,18 +11,17 @@ class CaptureRequest extends AbstractRequest
 {
     public function getData()
     {
-        $this->validate('transactionReference', 'amount');
+        $this->validate('transactionReference');
 
-        $data = array();
-        $data['amount'] = $this->getAmountInteger();
+        // Amount is the only possible optional parameter
+        $amount = $this->getAmountInteger();
 
-        return $data;
+        return $amount ? array('amount' => $amount) : array();
     }
 
     public function sendData($data)
     {
-        $httpResponse = $this->sendRequest('/charges/' . $this->getTransactionReference() . '/capture', $data);
-
+        $httpResponse = $this->sendRequest('/charges/' . $this->getTransactionReference() . '/capture', $data, RequestInterface::PUT);
         return $this->response = new CaptureResponse($this, $httpResponse->json());
     }
 }

--- a/src/Message/CaptureRequest.php
+++ b/src/Message/CaptureRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Omnipay\Pin\Message;
+
+/**
+ * Pin Capture Request
+ */
+class CaptureRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference', 'amount');
+
+        $data = array();
+        $data['amount'] = $this->getAmountInteger();
+
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        $httpResponse = $this->sendRequest('/charges/' . $this->getTransactionReference() . '/capture', $data);
+
+        return $this->response = new CaptureResponse($this, $httpResponse->json());
+    }
+}

--- a/src/Message/CaptureResponse.php
+++ b/src/Message/CaptureResponse.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Pin Response
+ */
+
+namespace Omnipay\Pin\Message;
+
+/**
+ * Pin Capture Response
+ *
+ * This is the response class for Pin Capture REST requests.
+ *
+ * @see \Omnipay\Pin\Gateway
+ */
+class CaptureResponse extends Response
+{
+    /**
+     * Get Captured value
+     *
+     * This is used after an attempt to capture the charge is made.
+     * If the capture was successful then it will return true.
+     *
+     * @return string
+     */
+    public function getCaptured()
+    {
+        if (isset($this->data['response']['captured'])) {
+            return $this->data['response']['captured'];
+        }
+    }
+
+}

--- a/src/Message/CaptureResponse.php
+++ b/src/Message/CaptureResponse.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Pin Response
+ * Pin Capture Response
  */
 
 namespace Omnipay\Pin\Message;
@@ -28,5 +28,4 @@ class CaptureResponse extends Response
             return $this->data['response']['captured'];
         }
     }
-
 }

--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -69,9 +69,11 @@ class CreateCustomerRequest extends AbstractRequest
 {
     public function getData()
     {
+        $this->validate('email');
+
         $data = array();
-        // FIXME -- this won't work if there is no card.
-        $data['email'] = $this->getCard()->getEmail();
+
+        $data['email'] = $this->getEmail();
 
         if ($this->getToken()) {
             $data['card_token'] = $this->getToken();

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -93,13 +93,11 @@ class PurchaseRequest extends AbstractRequest
 {
     public function getData()
     {
-        $this->validate('amount', 'card');
+        $this->validate('amount', 'email', 'description');
 
         $data = array();
 
-        // FIXME -- this won't work if there is no card.
-        $data['email'] = $this->getCard()->getEmail();
-
+        $data['email'] = $this->getEmail();
         $data['amount'] = $this->getAmountInteger();
         $data['currency'] = strtolower($this->getCurrency());
         $data['description'] = $this->getDescription();

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -94,10 +94,12 @@ class PurchaseRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('amount', 'card');
-        // FIXME -- this won't work if there is no card.
-        $data['email'] = $this->getCard()->getEmail();
 
         $data = array();
+
+        // FIXME -- this won't work if there is no card.
+        $data['email'] = $this->getCard()->getEmail();
+        
         $data['amount'] = $this->getAmountInteger();
         $data['currency'] = strtolower($this->getCurrency());
         $data['description'] = $this->getDescription();

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -102,6 +102,7 @@ class PurchaseRequest extends AbstractRequest
         $data['currency'] = strtolower($this->getCurrency());
         $data['description'] = $this->getDescription();
         $data['ip_address'] = $this->getClientIp();
+        $data['capture'] = $this->getCapture();
 
         if ($token = $this->getToken()) {
             if (strpos($token, 'card_') !== false) {
@@ -133,5 +134,13 @@ class PurchaseRequest extends AbstractRequest
         $httpResponse = $this->sendRequest('/charges', $data);
 
         return $this->response = new Response($this, $httpResponse->json());
+    }
+
+    public function getCapture()
+    {
+        $capture = $this->getParameter('capture');
+
+        // By default with Pin a transaction is captured.
+        return $capture === null ? true : $capture;
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -141,6 +141,6 @@ class PurchaseRequest extends AbstractRequest
         $capture = $this->getParameter('capture');
 
         // By default with Pin a transaction is captured.
-        return $capture === null ? true : $capture;
+        return $capture === false ? 'false' : 'true';
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -99,7 +99,7 @@ class PurchaseRequest extends AbstractRequest
 
         // FIXME -- this won't work if there is no card.
         $data['email'] = $this->getCard()->getEmail();
-        
+
         $data['amount'] = $this->getAmountInteger();
         $data['currency'] = strtolower($this->getCurrency());
         $data['description'] = $this->getDescription();
@@ -138,11 +138,37 @@ class PurchaseRequest extends AbstractRequest
         return $this->response = new Response($this, $httpResponse->json());
     }
 
+    /**
+     * Get the Capture flag.
+     *
+     * Returns the capture parameter, which states whether the charge is
+     * just an authorisation or it is captured instantly. By default all
+     * charges are captured. Please note that the return has to be a string
+     * and not a boolean or Pin's API will disregard it and consider it set
+     * to 'true'
+     *
+     * @return string
+     */
     public function getCapture()
     {
         $capture = $this->getParameter('capture');
 
         // By default with Pin a transaction is captured.
         return $capture === false ? 'false' : 'true';
+    }
+
+    /**
+     * Set the capture flag.
+     *
+     * This flag states whether the charge is just an authorisation or it is
+     * captured instantly. By default all charges are captured.
+     *
+     * @param $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setCapture($value)
+    {
+        return $this->setParameter('capture', $value);
     }
 }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -15,6 +15,8 @@ class GatewayTest extends GatewayTestCase
         $this->options = array(
             'amount' => '10.00',
             'card'   => $this->getValidCard(),
+            'email'       => 'roland@pin.net.au',
+            'description' => 'test charge'
         );
     }
 

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -113,4 +113,28 @@ class GatewayTest extends GatewayTestCase
         $this->assertNull($response->getCustomerToken());
         $this->assertSame('One or more parameters were missing or invalid', $response->getMessage());
     }
+
+    public function testCaptureSuccess()
+    {
+        $this->setMockHttpResponse('CaptureSuccess.txt');
+
+        $response = $this->gateway->capture(array('amount' => '400.00', 'transactionReference' => 'ch_bZ3RhJnIUZ8HhfvH8CCvfA'))->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEquals('ch_lfUYEBK14zotCTykezJkfg', $response->getTransactionReference());
+        $this->assertTrue($response->getCaptured());
+    }
+
+    public function testCaptureError()
+    {
+        $this->setMockHttpResponse('CaptureFailure.txt');
+
+        $response = $this->gateway->capture(array('amount' => '400.00', 'transactionReference' => 'ch_lfUYEBK14zotCTykezJkfg'))->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('The authorisation has expired and can not be captured.', $response->getMessage());
+    }
 }

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Omnipay\Pin\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CaptureRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransactionReference('ch_bZ3RhJnIUZ8HhfvH8CCvfA')
+            ->setAmount('400.00');
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('CaptureSuccess.txt');
+        $response = $this->request->send();
+        $data = $response->getData();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEquals('ch_lfUYEBK14zotCTykezJkfg', $response->getTransactionReference());
+
+        $this->assertTrue($data['response']['captured']);
+    }
+
+    public function testSendError()
+    {
+        $this->setMockHttpResponse('CaptureFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('The authorisation has expired and can not be captured.', $response->getMessage());
+    }
+}

--- a/tests/Message/CaptureResponseTest.php
+++ b/tests/Message/CaptureResponseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omnipay\Pin\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CaptureResponseTest extends TestCase
+{
+    public function testCaptureSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('CaptureSuccess.txt');
+        $response = new CaptureResponse($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertEquals('ch_lfUYEBK14zotCTykezJkfg', $response->getTransactionReference());
+        $this->assertTrue($response->getCaptured());
+    }
+
+    public function testCaptureFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('CaptureFailure.txt');
+        $response = new CaptureResponse($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('The authorisation has expired and can not be captured.', $response->getMessage());
+        $this->assertNull($response->getCaptured());
+    }
+}

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -11,9 +11,11 @@ class PurchaseRequestTest extends TestCase
         $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
-                'amount'   => '10.00',
-                'currency' => 'AUD',
-                'card'     => $this->getValidCard(),
+                'amount'      => '10.00',
+                'currency'    => 'AUD',
+                'card'        => $this->getValidCard(),
+                'email'       => 'roland@pin.net.au',
+                'description' => 'test charge'
             )
         );
     }

--- a/tests/Mock/CaptureFailure.txt
+++ b/tests/Mock/CaptureFailure.txt
@@ -1,4 +1,4 @@
-HTTP/1.1 200 OK
+HTTP/1.1 400 AUTHORISATION_EXPIRED
 Cache-Control: max-age=0, private, must-revalidate
 Content-Type: application/json; charset=utf-8
 Date: Fri, 15 Feb 2013 15:42:42 GMT
@@ -15,4 +15,4 @@ X-UA-Compatible: IE=Edge,chrome=1
 Content-Length: 584
 Connection: keep-alive
 
-{"error":"invalid_resource","error_description":"One or more parameters were missing or invalid","messages":[{"param":"expiry_month","code":"expiry_month_invalid","message":"Expiry month can't be blank"}]}
+{"error":"authorisation_expired","error_description":"The authorisation has expired and can not be captured.","charge_token":"ch_lfUYEBK14zotCTykezJkfg"}

--- a/tests/Mock/CaptureSuccess.txt
+++ b/tests/Mock/CaptureSuccess.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Cache-Control: max-age=0, private, must-revalidate
+Content-Type: application/json; charset=utf-8
+Date: Fri, 15 Feb 2013 15:42:42 GMT
+ETag: "e0b6339dc44a19a2901de1447ec94ebb"
+Server: Apache/2.2.20 (Ubuntu)
+Status: 200
+Strict-Transport-Security: max-age=31536000
+Vary: User-Agent
+X-Powered-By: Phusion Passenger (mod_rails/mod_rack) 3.0.11
+X-Rack-Cache: invalidate, pass
+X-Request-Id: 6444d2d9467ed2a7ace471522f2d439b
+X-Runtime: 0.245244
+X-UA-Compatible: IE=Edge,chrome=1
+Content-Length: 584
+Connection: keep-alive
+
+{"response":{"token":"ch_lfUYEBK14zotCTykezJkfg","success":true,"amount":400,"currency":"USD","description":"test charge","email":"roland@pin.net.au","ip_address":"203.192.1.172","created_at":"2012-06-20T03:10:49Z","status_message":"Success","error_message":null,"card":{"token":"card_pIQJKMs93GsCc9vLSLevbw","scheme":"master","display_number":"XXXX-XXXX-XXXX-0000","expiry_month":6,"expiry_year":2020,"name":"RolandRobot","address_line1":"42 Sevenoaks St","address_line2":null,"address_city":"Lathlain","address_postcode":"6454","address_state":"WA","address_country":"Australia","primary":null},"captured":true,"authorisation_expired":false,"transfer":[],"amount_refunded":0,"total_fees":42,"merchant_entitlement":358,"refund_pending":false,"settlement_currency":"AUD"}}

--- a/tests/Mock/CardFailure.txt
+++ b/tests/Mock/CardFailure.txt
@@ -6,7 +6,7 @@ ETag: "e0b6339dc44a19a2901de1447ec94ebb"
 Server: Apache/2.2.20 (Ubuntu)
 Status: 200
 Strict-Transport-Security: max-age=31536000
-Vary: Use-Agent
+Vary: User-Agent
 X-Powered-By: Phusion Passenger (mod_rails/mod_rack) 3.0.11
 X-Rack-Cache: invalidate, pass
 X-Request-Id: 6444d2d9467ed2a7ace471522f2d439b


### PR DESCRIPTION
Up until now it was not possible to create an authorisation with Pin Payments via the Omnipay library. It is now possible and also the payment can be captured afterwards.