### PR TITLE
Update endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Total Downloads](https://poser.pugx.org/omnipay/pin/d/total.png)](https://packagist.org/packages/omnipay/pin)
 
 [Omnipay](https://github.com/thephpleague/omnipay) is a framework agnostic, multi-gateway payment
-processing library for PHP 5.3+. This package implements [Pin](https://pin.net.au/) support for Omnipay.
+processing library for PHP 5.3+. This package implements [Pin](https://pinpayments.com/) support for Omnipay.
 
-[Pin Payments](https://pin.net.au/) is an Australian all-in-one payment system, allowing you
+[Pin Payments](https://pinpayments.com/) is an Australian all-in-one payment system, allowing you
 to accept multi-currency credit card payments without a security
 deposit or a merchant account.
  

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -40,14 +40,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      *
      * @var string URL
      */
-    protected $testEndpoint = 'https://test-api.pin.net.au/';
+    protected $testEndpoint = 'https://test-api.pinpayments.com/';
 
     /**
      * Live Endpoint URL
      *
      * @var string URL
      */
-    protected $liveEndpoint = 'https://api.pin.net.au/';
+    protected $liveEndpoint = 'https://api.pinpayments.com/';
 
     /**
      * Get secret key


### PR DESCRIPTION
Pin Payments updated their primary domain to pinpayments.com at the end of 2017.  Updating the referenced URLs here to match.

I don't think this needs any tests.

**Ref:**
https://pinpayments.com/blog/moving-our-home-to-pinpayments